### PR TITLE
Adding a read-cell-value multimethod implementation for cells with Error

### DIFF
--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -21,6 +21,7 @@
 	   (if date-format? 
 	     (DateUtil/getJavaDate (.getNumberValue cv))
 	     (.getNumberValue cv)))
+(defmethod read-cell-value Cell/CELL_TYPE_ERROR [cv _] "ERROR")
 
 (defmulti read-cell #(.getCellType %))
 (defmethod read-cell Cell/CELL_TYPE_BLANK     [_]     nil)


### PR DESCRIPTION
Hi,

When I tried to read a spreadsheet with cells that contain errors, I've got the following error message:

#<CompilerException java.lang.RuntimeException: java.lang.IllegalArgumentException: No method in multimethod 'read-cell-value' for dispatch value: 5 (REPL:1)>

That's why I fork the repo and implemented this fix (commit db7bc17d4)

Please merge this into the main repo if you think it is fine.

Thank you very much!