### PR TITLE
Adding a read-cell-value multimethod implementation for cells with Error

### DIFF
--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -21,6 +21,7 @@
 	   (if date-format? 
 	     (DateUtil/getJavaDate (.getNumberValue cv))
 	     (.getNumberValue cv)))
+(defmethod read-cell-value Cell/CELL_TYPE_ERROR [cv _] :error)
 
 (defmulti read-cell #(.getCellType %))
 (defmethod read-cell Cell/CELL_TYPE_BLANK     [_]     nil)


### PR DESCRIPTION
I follow your advice (on cell_type_error branch) to return :error instead of "ERROR" for the implementation of read-cell and the Cell/CELL_TYPE_ERROR clause. Let me know if this is what you meant.