### PR TITLE
Returning exceptions as cell values instead of aborting execution

### DIFF
--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -26,10 +26,12 @@
 (defmethod read-cell Cell/CELL_TYPE_BLANK     [_]     nil)
 (defmethod read-cell Cell/CELL_TYPE_STRING    [cell]  (.getStringCellValue cell))
 (defmethod read-cell Cell/CELL_TYPE_FORMULA   [cell]
-	   (let [evaluator (.. cell getSheet getWorkbook
-			       getCreationHelper createFormulaEvaluator)
-		 cv (.evaluate evaluator cell)]
-	     (read-cell-value cv false)))
+  (try
+    (let [evaluator (.. cell getSheet getWorkbook
+                        getCreationHelper createFormulaEvaluator)
+          cv (.evaluate evaluator cell)]
+      (read-cell-value cv false))
+    (catch Exception e e)))
 (defmethod read-cell Cell/CELL_TYPE_BOOLEAN   [cell]  (.getBooleanCellValue cell))
 (defmethod read-cell Cell/CELL_TYPE_NUMERIC   [cell]
   (if (DateUtil/isCellDateFormatted cell)


### PR DESCRIPTION
In the old version of the library, thrown exceptions while reading cells would terminate the entire operation, e.g. when selecting rows. The underlying framework throws quite a lot of exceptions, especially for unsupported formulas. This change returns the exception as the value of the cell.