### PR TITLE
Added load-workbook-as-resource.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,14 +4,15 @@
   :license {:name "MIT License"
             :url "http://http://en.wikipedia.org/wiki/MIT_License"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-		 [org.apache.poi/poi "3.11"]
-		 [org.apache.poi/poi-ooxml "3.11"]]
+                 [org.apache.poi/poi "3.11"]
+                 [org.apache.poi/poi-ooxml "3.11"]]
   :plugins [[lein-difftest "2.0.0"]]
-  :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
-             :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :test {:global-vars {*warn-on-reflection* false}}}
+  :profiles {:1.3  {:dependencies [[org.clojure/clojure "1.3.0"]]}
+             :1.4  {:dependencies [[org.clojure/clojure "1.4.0"]]}
+             :1.5  {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :test {:global-vars  {*warn-on-reflection* false}
+                    :dependencies [[com.cemerick/pomegranate "0.3.0"]]}}
   :aliases {"all" ["with-profile" "1.3:1.4:1.5:1.6"]}
   :global-vars {*warn-on-reflection* true})
 

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -56,6 +56,15 @@
   (with-open [stream (FileInputStream. filename)]
     (WorkbookFactory/create stream)))
 
+(defn load-workbook-as-resource
+  "Load an Excel workbook from a named resource.
+  Used when reading from a resource on a classpath
+  as in case of application servers."
+  [^String resource]
+  (let [url (clojure.java.io/resource resource)]
+    (with-open [stream (.openStream url)]
+      (WorkbookFactory/create stream))))
+
 (defn save-workbook!
   "Save the workbook into a file."
   [^String filename ^Workbook workbook]

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -1,6 +1,6 @@
 (ns dk.ative.docjure.spreadsheet
   (:import
-   (java.io FileOutputStream FileInputStream)
+    (java.io FileOutputStream FileInputStream InputStream)
    (java.util Date Calendar)
    (org.apache.poi.xssf.usermodel XSSFWorkbook)
    (org.apache.poi.hssf.usermodel HSSFWorkbook)
@@ -50,20 +50,34 @@
 (defmethod read-cell Cell/CELL_TYPE_ERROR     [^Cell cell]
   (keyword (.name (FormulaError/forInt (.getErrorCellValue cell)))))
 
-(defn load-workbook
+(defn load-workbook-as-stream
+  "Load an Excel workbook from a stream.
+  A caller is required to close the stream after loading is complete."
+  [^InputStream stream]
+  (WorkbookFactory/create stream))
+
+(defn load-workbook-as-file
   "Load an Excel .xls or .xlsx workbook from a file."
   [^String filename]
   (with-open [stream (FileInputStream. filename)]
-    (WorkbookFactory/create stream)))
+    (load-workbook-as-stream stream)))
 
 (defn load-workbook-as-resource
   "Load an Excel workbook from a named resource.
   Used when reading from a resource on a classpath
-  as in case of application servers."
+  as in the case of running on an application server."
   [^String resource]
   (let [url (clojure.java.io/resource resource)]
     (with-open [stream (.openStream url)]
-      (WorkbookFactory/create stream))))
+      (load-workbook-as-stream stream))))
+
+(defn load-workbook
+  "DEPRECATED: Use 'load-workbook-as-file'.
+  Load an Excel .xls or .xlsx workbook from a file."
+  {:deprecated "1.9"}
+  [^String filename]
+  (println "WARNING: 'load-workbook' is deprecated. Use 'load-workbook-as-file'.")
+  (load-workbook-as-file filename))
 
 (defn save-workbook!
   "Save the workbook into a file."

--- a/test/dk/ative/docjure/xls_test.clj
+++ b/test/dk/ative/docjure/xls_test.clj
@@ -553,7 +553,7 @@
 ;; ----------------------------------------------------------------
 
 (defn- datatypes-rows [file]
-  (->> (load-workbook file)
+  (->> (load-workbook-as-file file)
        sheet-seq
        first
        (select-columns datatypes-map)))
@@ -583,7 +583,7 @@
 (deftest select-columns-formula-evaluation-integration-test
   (testing "Formula evaluation"
     (let [file (config :formulae-file)
-	  formula-expected-pairs (->> (load-workbook file)
+	  formula-expected-pairs (->> (load-workbook-as-file file)
 				      sheet-seq
 				      first
 				      (select-columns formulae-map)


### PR DESCRIPTION
The existing load-workbook function has a file name as a parameter. In the case when the workbook is attempted to be loaded from a file on a classpath, which is a typical case for application servers, the server does not have access to the file system, and the FileNotFound exception is thrown.

The new function uses a named resource, instead of a file name, to load the workbook.