### PR TITLE
cell-fn Excel to Clojure Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ to the top header row, then save the spreadsheet.
         (save-workbook! "spreadsheet.xlsx" wb)))
 
 
+### Example: Use Excel Formulas in Clojure
+
+Docjure allows you not only to evaluate a formula cell in a speadsheet, it also
+provides a way of exposing a formla in a cell as a Clojure function using the
+`cell-fn` function.
+
+    (use 'dk.active.docjure.spreadsheet)
+    ;; Load a speadsheet and take the first sheet, construct a function from cell A2, taking
+    ;; A1 as input.
+    (def formula-from-a2 (cell-fn "A2"
+                                      (first (sheet-seq (load-workbook "spreadsheet.xslx")))
+                                      "A1"))
+
+    ;; Returns value of cell A2, as if value in cell A1 were 1.0
+    (formula-from-a2 1.0)
+
 ### Example: Handling Error Cells
 
 If the spreadsheet being read contains cells with errors the default

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -559,6 +559,4 @@
   (fn [& input] (do
                   (doseq [pair (seq (apply hash-map (interleave inputcells input)))]
                     (set-cell! (select-cell (first pair) sheet) (last pair)))
-                  (read-cell (select-cell outputcell sheet))
-                  ;;(seq (apply hash-map (interleave inputcells input)))
-                  )))
+                  (read-cell (select-cell outputcell sheet)))))

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -522,3 +522,16 @@
   (let [the-name (.createName workbook)]
     (.setNameName the-name (name n))
     (.setRefersToFormula the-name string-ref)))
+
+(defn cell-fn
+  "Turn a cell (ideally containing a formula) into a function. The returned function
+  will take a variable number of parameters, updating each of the inputcells in the
+  sheet with the supplied values and return the value of the cell outputcell.
+  Cell names are specified using Excel syntax, i.e. A2 or B12."
+  [outputcell ^Sheet sheet & inputcells]
+  (fn [& input] (do
+                  (doseq [pair (seq (apply hash-map (interleave inputcells input)))]
+                    (set-cell! (select-cell (first pair) sheet) (last pair)))
+                  (read-cell (select-cell outputcell sheet))
+                  ;;(seq (apply hash-map (interleave inputcells input)))
+                  )))

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -200,21 +200,31 @@
 (defmulti set-cell! (fn [^Cell cell val] (type val)))
 
 (defmethod set-cell! String [^Cell cell val]
-  (.setCellValue cell ^String val))
+  (do
+    (if (= (.getCellType cell) Cell/CELL_TYPE_FORMULA) (.setCellType cell Cell/CELL_TYPE_STRING))
+    (.setCellValue cell ^String val)))
 
 (defmethod set-cell! Number [^Cell cell val]
-  (.setCellValue cell (double val)))
+  (do
+    (if (= (.getCellType cell) Cell/CELL_TYPE_FORMULA) (.setCellType cell Cell/CELL_TYPE_NUMERIC))
+    (.setCellValue cell (double val))))
 
 (defmethod set-cell! Boolean [^Cell cell val]
-  (.setCellValue cell ^Boolean val))
+  (do
+    (if (= (.getCellType cell) Cell/CELL_TYPE_FORMULA) (.setCellType cell Cell/CELL_TYPE_BOOLEAN))
+    (.setCellValue cell ^Boolean val)))
 
 (defmethod set-cell! Date [^Cell cell val]
-  (do (.setCellValue cell ^Date val)
-      (apply-date-format! cell "m/d/yy")))
+  (do
+    (if (= (.getCellType cell) Cell/CELL_TYPE_FORMULA) (.setCellType cell Cell/CELL_TYPE_NUMERIC))
+    (.setCellValue cell ^Date val)
+    (apply-date-format! cell "m/d/yy")))
 
 (defmethod set-cell! nil [^Cell cell val]
   (let [^String null nil]
-      (.setCellValue cell null)))
+    (do
+      (if (= (.getCellType cell) Cell/CELL_TYPE_FORMULA) (.setCellType cell Cell/CELL_TYPE_BLANK))
+      (.setCellValue cell null))))
 
 (defn add-row! [^Sheet sheet values]
   (assert-type sheet Sheet)

--- a/test/dk/ative/docjure/spreadsheet_test.clj
+++ b/test/dk/ative/docjure/spreadsheet_test.clj
@@ -585,10 +585,15 @@
       (is (= (list cs1 cs2) (get-row-styles header-row)))
       )))
 
-((let [file (config :simple)
-        loaded (load-workbook file)
-        worksheet (first (sheet-seq loaded))]
-  (cell-fn "B3" worksheet "A2")) 4.0)
+(deftest cell-fn-test
+  (testing "Creating a function from a formula cell"
+    (let [file (config :simple)
+           loaded (load-workbook file)
+           worksheet (first (sheet-seq loaded))
+           cell-function (cell-fn "B3" worksheet "A2")]
+       (is (= (cell-function 2.0) 5.0))
+       (is (= (cell-function 3.0) 7.0))
+       )))
 
 ;; ----------------------------------------------------------------
 ;; Integration tests

--- a/test/dk/ative/docjure/spreadsheet_test.clj
+++ b/test/dk/ative/docjure/spreadsheet_test.clj
@@ -716,3 +716,15 @@
         (is (= 2.0      (read-cell (select-cell "A2" worksheet))))
         (is (= 3.0      (read-cell (select-cell "B2" worksheet))))
         (is (= 5.0      (read-cell (select-cell "B3" worksheet))))))))
+
+(deftest select-cell-overwrite-formula-read-updated-formula-test
+  (let [file (config :simple)
+        loaded (load-workbook file)
+        worksheet (first (sheet-seq loaded))]
+    (testing "selecting-cell"
+      (is (= 2.0      (read-cell (select-cell "B2" worksheet))))
+      (testing "updating cell-value"
+        (set-cell! (select-cell "B2" worksheet) 4.0)
+        (is (= 1.0      (read-cell (select-cell "A2" worksheet))))
+        (is (= 4.0      (read-cell (select-cell "B2" worksheet))))
+        (is (= 5.0      (read-cell (select-cell "B3" worksheet))))))))

--- a/test/dk/ative/docjure/spreadsheet_test.clj
+++ b/test/dk/ative/docjure/spreadsheet_test.clj
@@ -583,6 +583,11 @@
       (is (= (list cs1 cs2) (get-row-styles header-row)))
       )))
 
+((let [file (config :simple)
+        loaded (load-workbook file)
+        worksheet (first (sheet-seq loaded))]
+  (cell-fn "B3" worksheet "A2")) 4.0)
+
 ;; ----------------------------------------------------------------
 ;; Integration tests
 ;; ----------------------------------------------------------------
@@ -647,7 +652,6 @@
              (is (= (reduce concat (map (fn [[_ a b]] [a b]) data))
                     (map read-cell (select-name workbook "ten"))))
              (is (nil? (select-name workbook "bill"))))))
-
 
 (deftest date-bases-test
   (letfn [(read-sheet [file]


### PR DESCRIPTION
This pull request will provide a new function, `cell-fn` which will take a list of cells from a spreadsheet and and return a function. The returned function will always return the value of the first cell passed, but before doing so, it will update the spreadsheet with the values provided for the other cells that have been used as arguments to `cell-fn` and recalculate the formula for the result cell.

This allows treating the spreadsheet itself as a Clojure function, effectively allowing business users to use Microsoft Excel as a crude, but familiar domain specific language, to specify formulas/functions.

The base implementation does not optimize performance in any way, so before building mission-critical real-time apps based on Excel formulas, you might want to sprinkle some `memoize` magic on top.

The pull request also contains a fix for an issue where setting the value of a cell that contains a formula would not correctly update the cell value, only the cached output of the formula calculation. See https://github.com/mjul/docjure/commit/adeaf5efe919ca25c0155da05d24d5c6e7810786 for the exact diff.