### PR TITLE
Allow creating workbooks with multiple sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,28 @@ to the top header row, then save the spreadsheet.
     (save-workbook! "spreadsheet.xlsx" wb)))
 ```
 
+### Example: Create a workbook with multiple sheets
+This example creates a spreadsheet with multiple sheets. Instead of just passing a
+sheet name and a dataset, we pass a vector of the form [SheetName1, SheetData1,
+SheetName2, SheetData2, ...].
+
+```clj
+(use 'dk.ative.docjure.spreadsheet)
+
+;; Create a spreadsheet and save it
+(let [wb (create-workbook ["Squares"
+                           [["N" "N^2"]
+                            [1 1]
+                            [2 4]
+                            [3 9]]
+                           "Cubes"
+                           [["N" "N^3"]
+                            [1 1]
+                            [2 8]
+                            [3 27]]])]
+   (save-workbook! "exponents.xlsx" wb)))
+```
+
 ### Example: Use Excel Formulas in Clojure
 
 Docjure allows you not only to evaluate a formula cell in a speadsheet, it also

--- a/README.md
+++ b/README.md
@@ -83,24 +83,24 @@ to the top header row, then save the spreadsheet.
 ```
 
 ### Example: Create a workbook with multiple sheets
-This example creates a spreadsheet with multiple sheets. Instead of just passing a
-sheet name and a dataset, we pass a vector of the form [SheetName1, SheetData1,
-SheetName2, SheetData2, ...].
+This example creates a spreadsheet with multiple sheets. Simply add more
+sheet-name and data pairs. To create a sheet with no data, pass `nil` as
+the data argument.
 
 ```clj
 (use 'dk.ative.docjure.spreadsheet)
 
 ;; Create a spreadsheet and save it
-(let [wb (create-workbook ["Squares"
-                           [["N" "N^2"]
-                            [1 1]
-                            [2 4]
-                            [3 9]]
-                           "Cubes"
-                           [["N" "N^3"]
-                            [1 1]
-                            [2 8]
-                            [3 27]]])]
+(let [wb (create-workbook "Squares"
+                          [["N" "N^2"]
+                           [1 1]
+                           [2 4]
+                           [3 9]]
+                          "Cubes"
+                          [["N" "N^3"]
+                           [1 1]
+                           [2 8]
+                           [3 27]])]
    (save-workbook! "exponents.xlsx" wb)))
 ```
 

--- a/README.md
+++ b/README.md
@@ -253,5 +253,6 @@ This library includes great contributions from
 * [Jens Bendisposto](https://github.com/bendisposto) (bendisposto)
 * [Stuart Hinson](https://github.com/stuarth) (stuarth)
 * [Dan Petranek](https://github.com/dpetranek) (dpetranek)
+* [Aleksander Madland Stapnes](https://github.com/madstap) (madstap)
 
 Thank you very much!

--- a/README.md
+++ b/README.md
@@ -252,5 +252,6 @@ This library includes great contributions from
 * [Lars Trieloff](https://github.com/trieloff) (trieloff)
 * [Jens Bendisposto](https://github.com/bendisposto) (bendisposto)
 * [Stuart Hinson](https://github.com/stuarth) (stuarth)
+* [Dan Petranek](https://github.com/dpetranek) (dpetranek)
 
 Thank you very much!

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -293,7 +293,7 @@
   
   ([sheet-vec]
    (let [workbook (XSSFWorkbook.)
-        sheet-groups (partition 2 2 sheet-vec)
+        sheet-groups (partition 2 2 [nil] sheet-vec)
         sheets (map #(conj [] (add-sheet! workbook (first %)) (second %)) sheet-groups)]
     (doseq [sheet sheets]
       (add-rows! (first sheet) (second sheet)))

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -272,22 +272,32 @@
   (.createSheet workbook name))
 
 (defn create-workbook
-  "Create a new XLSX workbook with a single sheet and the data
-   specified. The data is given a vector of vectors, representing
+  "Create a new XLSX workbook. Data is a vector of vectors, representing
    the rows and the cells of the rows.
+  
+  Single sheet example: first argument is the sheet name, the second
+  argument is the sheet data.
 
-   For example, to create a workbook with a sheet with
-   two rows of each three columns:
+  (create-workbook \"SheetName1\" [[\"A1\" \"A2\"][\"B1\" \"B2\"]])
 
-   (create-workbook \"Sheet 1\"
-                    [[\"Name\" \"Quantity\" \"Price\"]
-                     [\"Foo Widget\" 2 42]])
-   "
-  [sheet-name data]
-  (let [workbook (XSSFWorkbook.)
-        sheet    (add-sheet! workbook sheet-name)]
-    (add-rows! sheet data)
-    workbook))
+  Multiple sheets example: one argument, a vector of alternating sheetnames and
+  associated sheetdata [SheetName1, SheetData1, SheetName2, SheetData2, ...]
+
+  (create-workbook [\"SheetName1\" [[\"FirstSheet A1\"][\"FirstSheet A2\"]]
+                    \"SheetName2\" [[\"SecondSheet A1\"][\"SecondSheet A2\"]]])"
+  ([sheet-name data]
+   (let [workbook (XSSFWorkbook.)
+         sheet    (add-sheet! workbook sheet-name)]
+     (add-rows! sheet data)
+     workbook))
+  
+  ([sheet-vec]
+   (let [workbook (XSSFWorkbook.)
+        sheet-groups (partition 2 2 sheet-vec)
+        sheets (map #(conj [] (add-sheet! workbook (first %)) (second %)) sheet-groups)]
+    (doseq [sheet sheets]
+      (add-rows! (first sheet) (second sheet)))
+    workbook)))
 
 (defn create-xls-workbook
   "Create a new XLS workbook with a single sheet and the data specified."

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -296,7 +296,7 @@
         sheet-groups (partition 2 2 [nil] sheet-vec)
         sheets (map #(conj [] (add-sheet! workbook (first %)) (second %)) sheet-groups)]
     (doseq [sheet sheets]
-      (add-rows! (first sheet) (second sheet)))
+      (apply add-rows! sheet))
     workbook)))
 
 (defn create-xls-workbook

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -272,31 +272,28 @@
   (.createSheet workbook name))
 
 (defn create-workbook
-  "Create a new XLSX workbook. Data is a vector of vectors, representing
-   the rows and the cells of the rows.
-  
-  Single sheet example: first argument is the sheet name, the second
-  argument is the sheet data.
+  "Create a new XLSX workbook.  Sheet-name is a string name for the sheet. Data 
+  is a vector of vectors, representing the rows and the cells of the rows. 
+  Alternate sheet names and data to create multiple sheets.
 
-  (create-workbook \"SheetName1\" [[\"A1\" \"A2\"][\"B1\" \"B2\"]])
-
-  Multiple sheets example: one argument, a vector of alternating sheetnames and
-  associated sheetdata [SheetName1, SheetData1, SheetName2, SheetData2, ...]
-
-  (create-workbook [\"SheetName1\" [[\"FirstSheet A1\"][\"FirstSheet A2\"]]
-                    \"SheetName2\" [[\"SecondSheet A1\"][\"SecondSheet A2\"]]])"
-  ([sheet-name data]
+  (create-workbook \"SheetName1\" [[\"A1\" \"A2\"][\"B1\" \"B2\"]]
+                   \"SheetName2\" [[\"A1\" \"A2\"][\"B1\" \"B2\"]] "
+ ([sheet-name data]
    (let [workbook (XSSFWorkbook.)
          sheet    (add-sheet! workbook sheet-name)]
      (add-rows! sheet data)
      workbook))
-  
-  ([sheet-vec]
-   (let [workbook (XSSFWorkbook.)
-        sheet-groups (partition 2 2 [nil] sheet-vec)
-        sheets (map #(conj [] (add-sheet! workbook (first %)) (second %)) sheet-groups)]
-    (doseq [sheet sheets]
-      (apply add-rows! sheet))
+ 
+ ([sheet-name data & name-data-pairs]
+  ;; incomplete pairs should not be allowed
+  {:pre [(even? (count name-data-pairs))]}
+  ;; call single arity version to create workbook
+   (let [workbook (create-workbook sheet-name data)]
+     ;; iterate through pairs adding sheets and rows
+    (doseq [[s-name data] (partition 2 name-data-pairs)]
+      (-> workbook
+          (add-sheet! s-name)
+          (add-rows!  data)))
     workbook)))
 
 (defn create-xls-workbook

--- a/test/dk/ative/docjure/spreadsheet_test.clj
+++ b/test/dk/ative/docjure/spreadsheet_test.clj
@@ -48,6 +48,46 @@
 	     (.getCell (second rows) 0) (first (second sheet-data))
 	     (.getCell (second rows) 1) (second (second sheet-data)))))))
 
+(deftest create-workbook-with-multiple-sheets-test
+  (let [sheet-vec ["Sheet 1" [["A1" "B1" "C1"]
+                              ["A2" "B2" "C2"]]
+                   "Sheet 2" [["A1" "B1" "C1"]
+                              ["A2" "B2" "C2"]]]
+        workbook (create-workbook sheet-vec)]
+    (testing "Multiple sheet creation"
+      (is (= 2 (.getNumberOfSheets workbook)) "Expected 2 sheets to be added.")
+      (is (= (nth sheet-vec 0) (.. workbook (getSheetAt 0) (getSheetName)))
+          "Expected sheet 1 to have correct name.")
+      (is (= (nth sheet-vec 2) (.. workbook (getSheetAt 1) (getSheetName)))
+          "Expected sheet 2 to have correct name."))
+    (testing "Sheet data"
+      (let [sheet1 (.getSheetAt workbook 0)
+            sheet1-rows (vec (iterator-seq (.iterator sheet1)))
+            sheet1-data (nth sheet-vec 1)
+            sheet2 (.getSheetAt workbook 1)
+            sheet2-rows (vec (iterator-seq (.iterator sheet2)))
+            sheet2-data (nth sheet-vec 3)]
+        (is (= (count (nth sheet-vec 1)) (.getPhysicalNumberOfRows sheet1))
+            "Expected correct number of rows for sheet 1.")
+        (is (= (count (nth sheet-vec 3)) (.getPhysicalNumberOfRows sheet2))
+            "Expected correct number of rows for sheet 2.")
+        (is (= 0 (.getRowNum (first sheet1-rows)) "Expected correct row number for sheet 1."))
+        (is (= 0 (.getRowNum (first sheet2-rows)) "Expected correct row number for sheet 2."))
+        (is (= (count (first (nth sheet-vec 1))) (.getLastCellNum (first sheet1-rows)))
+            "Expected correct number of columns for sheet 1.")
+        (is (= (count (first (nth sheet-vec 3))) (.getLastCellNum (first sheet2-rows)))
+            "Expected correct number of columns for sheet 2.")
+        (are [actual-cell expected-value] (= (expected-value (.getStringCellValue actual-cell)))
+              (.getCell (first sheet1-rows) 0) (ffirst sheet1-data)
+              (.getCell (first sheet1-rows) 1) (second (first sheet1-data))
+              (.getCell (second sheet1-rows) 0) (first (second sheet1-data))
+              (.getCell (second sheet1-rows) 1) (second (second sheet1-data))
+              
+              (.getCell (first sheet2-rows) 0) (ffirst sheet2-data)
+              (.getCell (first sheet2-rows) 1) (second (first sheet2-data))
+              (.getCell (second sheet2-rows) 0) (first (second sheet2-data))
+              (.getCell (second sheet2-rows) 1) (second (second sheet2-data)))))))
+
 (deftest row-vec-test
   (testing "Should transform row struct to row vector."
     (is (= ["foo" "bar"] (row-vec [:foo :bar] {:foo "foo", :bar "bar"}))

--- a/test/dk/ative/docjure/spreadsheet_test.clj
+++ b/test/dk/ative/docjure/spreadsheet_test.clj
@@ -1,7 +1,7 @@
 (ns dk.ative.docjure.spreadsheet-test
   (:use [dk.ative.docjure.spreadsheet] :reload-all)
   (:use [clojure.test])
-  (:require #_[cemerick.pomegranate :as pomegranate]
+  (:require [cemerick.pomegranate :as pomegranate]
            [clojure.java.io :as io])
   (:import (org.apache.poi.ss.usermodel Workbook Sheet Cell Row CellStyle IndexedColors Font CellValue)
            (org.apache.poi.xssf.usermodel XSSFWorkbook XSSFFont)
@@ -667,7 +667,7 @@
       (let [loaded (load-workbook stream)]
         (test-loaded-workbook loaded)))))
 
-#_(deftest load-workbook-from-resource-integration-test
+(deftest load-workbook-from-resource-integration-test
   (let [[dir file] (path->dir-and-file (config :datatypes-file))
         _ (pomegranate/add-classpath dir)
         loaded (load-workbook-from-resource file)]

--- a/test/dk/ative/docjure/spreadsheet_test.clj
+++ b/test/dk/ative/docjure/spreadsheet_test.clj
@@ -1,7 +1,7 @@
 (ns dk.ative.docjure.spreadsheet-test
   (:use [dk.ative.docjure.spreadsheet] :reload-all)
   (:use [clojure.test])
-  (require [cemerick.pomegranate :as pomegranate]
+  (:require #_[cemerick.pomegranate :as pomegranate]
            [clojure.java.io :as io])
   (:import (org.apache.poi.ss.usermodel Workbook Sheet Cell Row CellStyle IndexedColors Font CellValue)
            (org.apache.poi.xssf.usermodel XSSFWorkbook XSSFFont)
@@ -49,44 +49,44 @@
 	     (.getCell (second rows) 1) (second (second sheet-data)))))))
 
 (deftest create-workbook-with-multiple-sheets-test
-  (let [sheet-vec ["Sheet 1" [["A1" "B1" "C1"]
-                              ["A2" "B2" "C2"]]
-                   "Sheet 2" [["A1" "B1" "C1"]
-                              ["A2" "B2" "C2"]]]
-        workbook (create-workbook sheet-vec)]
+  (let [sheet-1-name "Sheet 1"
+        sheet-1-data [["A1" "B1" "C1"]
+                      ["A2" "B2" "C2"]]
+        sheet-2-name "Sheet 2"
+        sheet-2-data [["A1" "B1" "C1"]
+                      ["A2" "B2" "C2"]]
+        workbook (create-workbook sheet-1-name sheet-1-data sheet-2-name sheet-2-data)]
     (testing "Multiple sheet creation"
       (is (= 2 (.getNumberOfSheets workbook)) "Expected 2 sheets to be added.")
-      (is (= (nth sheet-vec 0) (.. workbook (getSheetAt 0) (getSheetName)))
+      (is (= sheet-1-name (.. workbook (getSheetAt 0) (getSheetName)))
           "Expected sheet 1 to have correct name.")
-      (is (= (nth sheet-vec 2) (.. workbook (getSheetAt 1) (getSheetName)))
+      (is (= sheet-2-name (.. workbook (getSheetAt 1) (getSheetName)))
           "Expected sheet 2 to have correct name."))
     (testing "Sheet data"
-      (let [sheet1 (.getSheetAt workbook 0)
-            sheet1-rows (vec (iterator-seq (.iterator sheet1)))
-            sheet1-data (nth sheet-vec 1)
-            sheet2 (.getSheetAt workbook 1)
-            sheet2-rows (vec (iterator-seq (.iterator sheet2)))
-            sheet2-data (nth sheet-vec 3)]
-        (is (= (count (nth sheet-vec 1)) (.getPhysicalNumberOfRows sheet1))
+      (let [sheet-1 (.getSheetAt workbook 0)
+            sheet-1-rows (vec (iterator-seq (.iterator sheet-1)))
+            sheet-2 (.getSheetAt workbook 1)
+            sheet-2-rows (vec (iterator-seq (.iterator sheet-2)))]
+        (is (= (count sheet-1-data) (.getPhysicalNumberOfRows sheet-1))
             "Expected correct number of rows for sheet 1.")
-        (is (= (count (nth sheet-vec 3)) (.getPhysicalNumberOfRows sheet2))
+        (is (= (count sheet-2-data) (.getPhysicalNumberOfRows sheet-2))
             "Expected correct number of rows for sheet 2.")
-        (is (= 0 (.getRowNum (first sheet1-rows)) "Expected correct row number for sheet 1."))
-        (is (= 0 (.getRowNum (first sheet2-rows)) "Expected correct row number for sheet 2."))
-        (is (= (count (first (nth sheet-vec 1))) (.getLastCellNum (first sheet1-rows)))
+        (is (= 0 (.getRowNum (first sheet-1-rows))) "Expected correct row number for sheet 1.")
+        (is (= 0 (.getRowNum (first sheet-2-rows))) "Expected correct row number for sheet 2.")
+        (is (= (count (first sheet-1-data)) (.getLastCellNum (first sheet-1-rows)))
             "Expected correct number of columns for sheet 1.")
-        (is (= (count (first (nth sheet-vec 3))) (.getLastCellNum (first sheet2-rows)))
+        (is (= (count (first sheet-2-data)) (.getLastCellNum (first sheet-2-rows)))
             "Expected correct number of columns for sheet 2.")
-        (are [actual-cell expected-value] (= (expected-value (.getStringCellValue actual-cell)))
-              (.getCell (first sheet1-rows) 0) (ffirst sheet1-data)
-              (.getCell (first sheet1-rows) 1) (second (first sheet1-data))
-              (.getCell (second sheet1-rows) 0) (first (second sheet1-data))
-              (.getCell (second sheet1-rows) 1) (second (second sheet1-data))
+        (are [actual-cell expected-value] (= expected-value (.getStringCellValue actual-cell))
+              (.getCell (first sheet-1-rows) 0) (ffirst sheet-1-data)
+              (.getCell (first sheet-1-rows) 1) (second (first sheet-1-data))
+              (.getCell (second sheet-1-rows) 0) (first (second sheet-1-data))
+              (.getCell (second sheet-1-rows) 1) (second (second sheet-1-data))
               
-              (.getCell (first sheet2-rows) 0) (ffirst sheet2-data)
-              (.getCell (first sheet2-rows) 1) (second (first sheet2-data))
-              (.getCell (second sheet2-rows) 0) (first (second sheet2-data))
-              (.getCell (second sheet2-rows) 1) (second (second sheet2-data)))))))
+              (.getCell (first sheet-2-rows) 0) (ffirst sheet-2-data)
+              (.getCell (first sheet-2-rows) 1) (second (first sheet-2-data))
+              (.getCell (second sheet-2-rows) 0) (first (second sheet-2-data))
+              (.getCell (second sheet-2-rows) 1) (second (second sheet-2-data)))))))
 
 (deftest row-vec-test
   (testing "Should transform row struct to row vector."
@@ -667,7 +667,7 @@
       (let [loaded (load-workbook stream)]
         (test-loaded-workbook loaded)))))
 
-(deftest load-workbook-from-resource-integration-test
+#_(deftest load-workbook-from-resource-integration-test
   (let [[dir file] (path->dir-and-file (config :datatypes-file))
         _ (pomegranate/add-classpath dir)
         loaded (load-workbook-from-resource file)]


### PR DESCRIPTION
Modifies the create-workbook function without breaking backwards
compatibly. The original arity of [sheetname data] is preserved,
but I added an arity of [sheet-vec] that takes a vector of
alternating sheetnames and sheetdata. 