### PR TITLE
Style additions - indent, data-format and border colours

### DIFF
--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -470,15 +470,21 @@
 (defn create-cell-style!
   "Create a new cell-style in the workbook from options:
 
-      :background    background colour (as keyword)
-      :font          font | fontmap (of font options)
-      :halign        :left | :right | :center
-      :valign        :top | :bottom | :center
-      :wrap          true | false - controls text wrapping
-      :border-left   :thin | :medium | :thick
-      :border-right  :thin | :medium | :thick
-      :border-top    :thin | :medium | :thick
-      :border-bottom :thin | :medium | :thick
+      :background          background colour (as keyword)
+      :font                font | fontmap (of font options)
+      :halign              :left | :right | :center
+      :valign              :top | :bottom | :center
+      :wrap                true | false - controls text wrapping
+      :border-left         :thin | :medium | :thick
+      :border-right        :thin | :medium | :thick
+      :border-top          :thin | :medium | :thick
+      :border-bottom       :thin | :medium | :thick
+      :left-border-color   colour keyword
+      :right-border-color  colour keyword
+      :top-border-color    colour keyword
+      :bottom-border-color colour keyword
+      :indent              number from 0 to 15
+      :data-format         string
 
    Valid color keywords are the colour names defined in
    org.apache.ss.usermodel.IndexedColors as lowercase keywords, eg.
@@ -489,11 +495,11 @@
    I.
    (def f (create-font! wb {:name \"Arial\", :bold true, :italic true})
    (create-cell-style! wb {:background :yellow, :font f, :halign :center,
-                           :wrap true, :borders :thin})
+                           :wrap true, :border-bottom :thin})
    II.
    (create-cell-style! wb {:background :yellow, :halign :center,
                            :font {:name \"Arial\" :bold true :italic true},
-                           :wrap true, :borders :thin})
+                           :wrap true, :border-bottom :thin})
   "
   ([^Workbook workbook] (create-cell-style! workbook {}))
 
@@ -501,8 +507,10 @@
      (assert-type workbook Workbook)
      (let [cs (.createCellStyle workbook)
            {:keys [background font halign valign wrap
-                   border-left border-right border-top
-                   border-bottom borders]} styles]
+                   border-left border-right border-top border-bottom
+                   left-border-color right-border-color
+                   top-border-color bottom-border-color
+                   borders indent data-format]} styles]
        (whens
         font   (set-font font cs workbook)
         background (do (.setFillForegroundColor cs (color-index background))
@@ -513,7 +521,18 @@
         border-left (.setBorderLeft cs (border border-left))
         border-right (.setBorderRight cs (border border-right))
         border-top (.setBorderTop cs (border border-top))
-        border-bottom (.setBorderBottom cs (border border-bottom)))
+        border-bottom (.setBorderBottom cs (border border-bottom))
+        left-border-color (.setLeftBorderColor
+                            cs (color-index left-border-color))
+        right-border-color (.setRightBorderColor
+                             cs (color-index right-border-color))
+        top-border-color (.setTopBorderColor
+                           cs (color-index top-border-color))
+        bottom-border-color (.setBottomBorderColor
+                              cs (color-index bottom-border-color))
+        indent (.setIndention cs (short indent))
+        data-format (let [df (.createDataFormat workbook)]
+                      (.setDataFormat cs (.getFormat df data-format))))
        cs)))
 
 (defn set-cell-style!

--- a/test/dk/ative/docjure/spreadsheet_test.clj
+++ b/test/dk/ative/docjure/spreadsheet_test.clj
@@ -463,7 +463,9 @@
         (is (= CellStyle/BORDER_NONE (.getBorderLeft cs)))
         (is (= CellStyle/BORDER_NONE (.getBorderRight cs)))
         (is (= CellStyle/BORDER_NONE (.getBorderTop cs)))
-        (is (= CellStyle/BORDER_NONE (.getBorderBottom cs)))))
+        (is (= CellStyle/BORDER_NONE (.getBorderBottom cs)))
+        (is (zero? (.getIndention cs)))
+        (is (= "General" (.getDataFormatString cs)))))
     (testing ":background"
       (let [wb (create-workbook "Dummy" [["foo"]])
             cs (create-cell-style! wb {:background :yellow})]
@@ -493,6 +495,24 @@
         (is (= CellStyle/BORDER_MEDIUM (.getBorderRight cs)))
         (is (= CellStyle/BORDER_THICK (.getBorderTop cs)))
         (is (= CellStyle/BORDER_THIN (.getBorderBottom cs)))))
+    (testing "border colors"
+      (let [wb (create-xls-workbook "Dummy" [["foo"]])
+            cs (create-cell-style! wb {:border-left :thin
+                                       :border-right :medium
+                                       :border-top :thick 
+                                       :border-bottom :thin
+                                       :left-border-color :red
+                                       :right-border-color :blue
+                                       :top-border-color :green
+                                       :bottom-border-color :yellow})]
+        (is (= CellStyle/BORDER_THIN (.getBorderLeft cs)))
+        (is (= CellStyle/BORDER_MEDIUM (.getBorderRight cs)))
+        (is (= CellStyle/BORDER_THICK (.getBorderTop cs)))
+        (is (= CellStyle/BORDER_THIN (.getBorderBottom cs)))
+        (is (= (.getIndex IndexedColors/RED) (.getLeftBorderColor cs)))
+        (is (= (.getIndex IndexedColors/BLUE) (.getRightBorderColor cs)))
+        (is (= (.getIndex IndexedColors/GREEN) (.getTopBorderColor cs)))
+        (is (= (.getIndex IndexedColors/YELLOW) (.getBottomBorderColor cs)))))
     (testing ":wrap"
       (let [wb (create-workbook "Dummy" [["foo"]])
             cs (create-cell-style! wb {:wrap :true})]
@@ -544,7 +564,19 @@
 	    cs (create-cell-style! wb {:font testfont})
             cs2 (create-cell-style! wb {:font fontmap})]
 	(is (= Font/U_SINGLE (.getUnderline (get-font cs wb))))
-        (is (= Font/U_SINGLE (.getUnderline (get-font cs2 wb))))))))
+        (is (= Font/U_SINGLE (.getUnderline (get-font cs2 wb))))))
+    (testing ":indent"
+      (let [wb (create-xls-workbook "Dummy" [["fonts"]])
+            cs (create-cell-style! wb {:indent 1})
+            cs2 (create-cell-style! wb {:indent 2})]
+        (is (= 1 (.getIndention cs)))
+        (is (= 2 (.getIndention cs2)))))
+    (testing ":data-format"
+      (let [wb (create-xls-workbook "Dummy" [["foo"]])
+            cs (create-cell-style! wb {:data-format "#,##0"})
+            cs2 (create-cell-style! wb {:data-format "#,##0"})]
+        (is (= "#,##0" (.getDataFormatString cs)))
+        (is (= (.getDataFormat cs) (.getDataFormat cs2)))))))
 
 (deftest create-font!-test
     (let [wb (create-workbook "Dummy" [["foo"]])]

--- a/test/dk/ative/docjure/xls_test.clj
+++ b/test/dk/ative/docjure/xls_test.clj
@@ -282,7 +282,9 @@
         (is (= CellStyle/BORDER_NONE (.getBorderLeft cs)))
         (is (= CellStyle/BORDER_NONE (.getBorderRight cs)))
         (is (= CellStyle/BORDER_NONE (.getBorderTop cs)))
-        (is (= CellStyle/BORDER_NONE (.getBorderBottom cs)))))
+        (is (= CellStyle/BORDER_NONE (.getBorderBottom cs)))
+        (is (zero? (.getIndention cs)))
+        (is (= "General" (.getDataFormatString cs)))))
     (testing ":background"
       (let [wb (create-xls-workbook "Dummy" [["foo"]])
             cs (create-cell-style! wb {:background :yellow})]
@@ -312,6 +314,24 @@
         (is (= CellStyle/BORDER_MEDIUM (.getBorderRight cs)))
         (is (= CellStyle/BORDER_THICK (.getBorderTop cs)))
         (is (= CellStyle/BORDER_THIN (.getBorderBottom cs)))))
+    (testing "border colors"
+      (let [wb (create-xls-workbook "Dummy" [["foo"]])
+            cs (create-cell-style! wb {:border-left :thin
+                                       :border-right :medium
+                                       :border-top :thick 
+                                       :border-bottom :thin
+                                       :left-border-color :red
+                                       :right-border-color :blue
+                                       :top-border-color :green
+                                       :bottom-border-color :yellow})]
+        (is (= CellStyle/BORDER_THIN (.getBorderLeft cs)))
+        (is (= CellStyle/BORDER_MEDIUM (.getBorderRight cs)))
+        (is (= CellStyle/BORDER_THICK (.getBorderTop cs)))
+        (is (= CellStyle/BORDER_THIN (.getBorderBottom cs)))
+        (is (= (.getIndex IndexedColors/RED) (.getLeftBorderColor cs)))
+        (is (= (.getIndex IndexedColors/BLUE) (.getRightBorderColor cs)))
+        (is (= (.getIndex IndexedColors/GREEN) (.getTopBorderColor cs)))
+        (is (= (.getIndex IndexedColors/YELLOW) (.getBottomBorderColor cs)))))
     (testing ":wrap"
       (let [wb (create-xls-workbook "Dummy" [["foo"]])
             cs (create-cell-style! wb {:wrap :true})]
@@ -363,7 +383,19 @@
 	    cs (create-cell-style! wb {:font testfont})
             cs2 (create-cell-style! wb {:font fontmap})]
 	(is (= Font/U_SINGLE (.getUnderline (get-font cs wb))))
-        (is (= Font/U_SINGLE (.getUnderline (get-font cs2 wb))))))))
+        (is (= Font/U_SINGLE (.getUnderline (get-font cs2 wb))))))
+    (testing ":indent"
+      (let [wb (create-xls-workbook "Dummy" [["foo"]])
+            cs (create-cell-style! wb {:indent 1})
+            cs2 (create-cell-style! wb {:indent 2})]
+        (is (= 1 (.getIndention cs)))
+        (is (= 2 (.getIndention cs2)))))
+    (testing ":data-format"
+      (let [wb (create-xls-workbook "Dummy" [["foo"]])
+            cs (create-cell-style! wb {:data-format "#,##0"})
+            cs2 (create-cell-style! wb {:data-format "#,##0"})]
+        (is (= "#,##0" (.getDataFormatString cs)))
+        (is (= (.getDataFormat cs) (.getDataFormat cs2)))))))
 
 (deftest create-font!-test
     (let [wb (create-xls-workbook "Dummy" [["foo"]])]


### PR DESCRIPTION
Some new options to `create-cell-style!` that I have been using myself and that may be useful to the community:

 - `:indent` - sets cell content indent (with a number from 0 to 15)
 - `:data-format` - sets data format string, e. g. "#,##0", "0.0%", etc.
 - `:left-border-color`, `:right-border-color`, `:top-border-color`, `:bottom-border-color` - sets border colours. A keyword is expected, just as with `:background` option.