### PR TITLE
Update POI to 3.17

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "MIT License"
             :url "http://http://en.wikipedia.org/wiki/MIT_License"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.apache.poi/poi "3.16"]
-                 [org.apache.poi/poi-ooxml "3.16"]]
+                 [org.apache.poi/poi "3.17"]
+                 [org.apache.poi/poi-ooxml "3.17"]]
   :plugins [[lein-difftest "2.0.0"]]
   :profiles {:1.3  {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4  {:dependencies [[org.clojure/clojure "1.4.0"]]}


### PR DESCRIPTION
Implement minimal updates to support the new POI version 3.17 with enums.

Available at `macroz/docjure` 1.12.0 for use before PR is merged.