### PR TITLE
record support for `spreadsheet/row-vec`

### DIFF
--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -618,8 +618,8 @@
      (row-vec [:foo :bar] {:foo \"Foo text\", :bar \"Bar text\"})
      > [\"Foo text\" \"Bar text\"]
   "
-  [column-order row]
-  (vec (map row column-order)))
+  [column-order row-struct]
+  (vec (map #(get row-struct %) column-order)))
 
 (defn remove-row!
   "Remove a row from the sheet. Rows are not shifted up - the removed row will display as blank"

--- a/test/dk/ative/docjure/spreadsheet_test.clj
+++ b/test/dk/ative/docjure/spreadsheet_test.clj
@@ -130,10 +130,14 @@
         (is (= "D5" (cellvalue 4 3)))
         ))))
 
+(defrecord RowStruct [foo bar])
+
 (deftest row-vec-test
   (testing "Should transform row struct to row vector."
     (is (= ["foo" "bar"] (row-vec [:foo :bar] {:foo "foo", :bar "bar"}))
 	"Should map all columns.")
+    (is (= ["foo" "bar"] (row-vec [:foo :bar] (->RowStruct "foo" "bar")))
+	"Should map record columns.")
     (is (= ["bar" "foo"] (row-vec [:bar :foo] {:foo "foo", :bar "bar"}))
 	"Should respect column order.")
     (is (= [nil nil] (row-vec [:foo :bar] {})) "Should generate all columns.")


### PR DESCRIPTION
Hi, 

Currently I can't create row using `spreadsheed/row-vec` by passing record instance as argument, because records does not support syntax `(<record-instance> :field)`  as maps do. PR solves this issue.