### PR TITLE
add function: select-columns-by-header

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ This library includes great contributions from
 * [Manuel Herzog](https://github.com/manuelherzog) (manuelherzog)
 * [Francisco Vides Fernández](https://github.com/fvides) (fvides)
 * [WonJun Lee](https://github.com/Lee-WonJun) (Lee-WonJun)
+* [Kimi Ma](https://github.com/kimim) (kimim)
 
 Thank you very much!
 

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -213,6 +213,22 @@
      (->> (map #(project-cell column-map %) row)
           (apply merge)))))
 
+(defn select-columns-by-header
+  "Takes a sheet. Returns a sequence of map with the names of header fields as the
+   key, and the value of following cells. The table in the sheet should occupy a
+   normal space.
+
+   For example, to select columns A and B according to the header from the sheet
+
+   (select-columns-by-header sheet)
+   => [{\"first\" \"Value in cell A2\", \"second\" \"Value in cell B2\"} ...] "
+  [^Sheet sheet]
+  (assert-type sheet Sheet)
+  (let [rows (->> sheet row-seq (map cell-seq) (map #(map read-cell %)))
+        thead (first rows)
+        tbody (rest rows)]
+    (vec (map #(zipmap thead %) tbody))))
+
 (defn string-cell? [^Cell cell]
   (= CellType/STRING (.getCellType cell)))
 

--- a/test/dk/ative/docjure/spreadsheet_test.clj
+++ b/test/dk/ative/docjure/spreadsheet_test.clj
@@ -518,7 +518,7 @@
       (let [wb (create-xls-workbook "Dummy" [["foo"]])
             cs (create-cell-style! wb {:border-left :thin
                                        :border-right :medium
-                                       :border-top :thick 
+                                       :border-top :thick
                                        :border-bottom :thin
                                        :left-border-color :red
                                        :right-border-color :blue
@@ -965,3 +965,18 @@
           loaded (load-workbook file)
           _ (io/delete-file file)]
       (test-loaded-workbook loaded))))
+
+(deftest auto-header-test
+  (letfn [(read-sheet [file]
+            (->> (load-workbook file)
+                 sheet-seq
+                 first
+                 (select-columns-by-header)))
+          (year [^java.util.Date date]
+            (+ 1900 (.getYear date)))]
+    (testing "Can read workbooks with 1900-based dates"
+      (let [actual (read-sheet (config :1900-based-file))]
+        (is (every? #(== (year (get % "Date")) (get % "Year")) actual))))
+    (testing "Can read workbooks with 1904-based dates"
+      (let [actual (read-sheet (config :1904-based-file))]
+        (is (every? #(== (year (get % "Date")) (get % "Year")) actual))))))


### PR DESCRIPTION
Sometimes, we may want to use the default table header as the column map keys, without specify additional column-map.