### PR TITLE
Fix reflection warnings on spreadsheet namespace evaluation

### DIFF
--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -576,7 +576,7 @@
                               cs (color-index bottom-border-color))
         indent (.setIndention cs (short indent))
         data-format (let [df (.createDataFormat workbook)]
-                      (.setDataFormat cs (.getFormat df data-format))))
+                      (.setDataFormat cs (.getFormat df ^String data-format))))
        cs)))
 
 (defn set-cell-style!

--- a/src/dk/ative/docjure/spreadsheet.clj
+++ b/src/dk/ative/docjure/spreadsheet.clj
@@ -701,7 +701,7 @@
 (defn select-cell
   "Given a Sheet and a cell reference (A1), select-cell returns the cell
   or nil if the cell could not be found"
-  [n ^Sheet sheet]
+  [^String n ^Sheet sheet]
   (let [cellref (CellReference. n)
         row (.getRow cellref)
         col (.getCol cellref)]


### PR DESCRIPTION
When the spreadsheet namespace is evaluated I get two reflection warnings printed out to my console

```
Reflection warning, dk/ative/docjure/spreadsheet.clj:705:17 - call to org.apache.poi.ss.util.CellReference ctor can't be resolved.
Reflection warning, dk/ative/docjure/spreadsheet.clj:579:42 - call to method getFormat on org.apache.poi.ss.usermodel.DataFormat can't be resolved (argument types: java.lang.Object).
```

This PR will resolve both warnings. More details are in the commit messages. All the tests pass locally for me. Let me know if there is anything I might need to do.