### PR TITLE
Upgrade Apache POI to mitigate CVE-2025-31672

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "MIT License"
             :url "http://http://en.wikipedia.org/wiki/MIT_License"}
   :dependencies [[org.clojure/clojure "1.12.0"]
-                 [org.apache.poi/poi "5.3.0"]
-                 [org.apache.poi/poi-ooxml "5.3.0"]]
+                 [org.apache.poi/poi "5.4.1"]
+                 [org.apache.poi/poi-ooxml "5.4.1"]]
   :plugins [[lein-difftest "2.0.0"]
             [lein-nvd "1.4.0"]
             [lein-ancient "0.6.15"]


### PR DESCRIPTION
Apache POI has a known vulnerability at the current version which can be resolved by upgrading to > 5.4.1

`lein nvd` also reports the vulnerability, and I was able to successfully execute tests with the `all` profile. 

CVE Finding: https://www.cve.org/CVERecord?id=CVE-2025-31672
Snyk Report: https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEPOI-9685010
Related Issue: https://github.com/mjul/docjure/issues/118

Please let me know if there's anything else you need!